### PR TITLE
feat(#9): Sending notifications when status change or when degrade

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -35,11 +35,11 @@ jobs:
         OWNER: ${{ github.repository_owner }}
 
     - name: Get Gem Version
-        id: get-version
-        run: |
-          VERSION=$(ruby -r './lib/rollout/version.rb' -e "puts Rollout::VERSION")
-          echo "::set-output name=version::$VERSION"
-        shell: bash
+      id: get-version
+      run: |
+        VERSION=$(ruby -r './lib/rollout/version.rb' -e "puts Rollout::VERSION")
+        echo "::set-output name=version::$VERSION"
+      shell: bash
 
     - name: Check if Gem Version Exists in ruby gems
       run: |

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -34,6 +34,21 @@ jobs:
         GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
         OWNER: ${{ github.repository_owner }}
 
+    - name: Get Gem Version
+        id: get-version
+        run: |
+          VERSION=$(ruby -r './lib/rollout/version.rb' -e "puts Rollout::VERSION")
+          echo "::set-output name=version::$VERSION"
+        shell: bash
+
+    - name: Check if Gem Version Exists in ruby gems
+      run: |
+        gem fetch rollout-redis -v ${{ steps.get-version.outputs.version }}
+          if [ $? -eq 0 ]; then
+            echo "Gem version already exists on RubyGems. Skipping the push to RubyGems."
+            exit 0
+          fi
+
     - name: Publish to RubyGems
       run: |
         mkdir -p $HOME/.gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.0.0] - 2023-MM-DD
+## [1.0.0] - 2023-10-25
 
 ### Added
 - `#with_notifications` method for allowing to send notifications when some different event occurs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0] - 2023-MM-DD
+
+### Added
+- `#with_notifications` method for allowing to send notifications when some different event occurs.
+
+### Changed
+- When the threshold of errors is reached when using the `with_degrade` feature, instead of deleting the feature flag from the redis, we are marking it now as degraded, moving the activation percentage to 0% and adding some useful information to the feature flag stored data.
+
+## [0.3.1] - 2023-10-24
+- Same as 0.3.0. When testing GitHub actions for moving to first release `1.0.0` it deployed a new version of the gem by error.
+
 ## [0.3.0] - 2023-10-24
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rollout-redis (0.2.0)
+    rollout-redis (1.0.0)
       redis (>= 4.0, <= 5)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ _NOTE_: All the managed or captured errors inside the wrapped code will not be t
 `rollout-redis` gem can send different notifications to your development team. For enabling this feature, you just need to use the `with_notifications` instance method providing the channels where you want to publish each of the different events that can occur:
 
 - **status_change**: This notification is triggered when a feature flag is activated or deactivated using the `rollout-redis` gem.
-- **degraded**: This notification is triggered when a feature flag is automatically degraded because the threshold of errors is reached
+- **degrade**: This notification is triggered when a feature flag is automatically degraded because the threshold of errors is reached
   - The instance must be configured for automatically degrading using the `with_degrade` instance method.
 
 You must provide at least one [channel](#defining-the-channels) as a parameter if you want to enable the notifications for that specific event. If no channels provided, the notifications will not be sent. 
@@ -179,7 +179,7 @@ You must provide at least one [channel](#defining-the-channels) as a parameter i
               .with_degrade(min: 100, threshold: 0.1)
               .with_notifications(
                 status_change: [slack_channel],
-                degraded: [slack_channel, email_channel]
+                degrade: [slack_channel, email_channel]
               )
 ```
 

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -73,7 +73,7 @@ class Rollout
       feature.add_error
       save(feature)
 
-      deactivate(feature_name) if degraded?(feature)
+      degrade(feature_name) if degraded?(feature)
     end
     raise e
   end
@@ -145,6 +145,16 @@ class Rollout
   
   def del(feature_name)
     @storage.del(key(feature_name)) == 1
+  end
+
+  def degrade(feature_name)
+    feature = get(feature_name)
+    data_with_degrade = feature.data.merge({
+      percentage: 0,
+      degraded: true,
+      degraded_at: Time.now
+    })
+    @storage.set(key(feature.name), data_with_degrade.to_json)
   end
 
   def from_cache(feature_name)

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
-require 'rollout/feature'
-require 'rollout/version'
 require 'redis'
 require 'json'
+
+require 'rollout/feature'
+require 'rollout/notifications/channels/email'
+require 'rollout/notifications/channels/slack'
+require 'rollout/notifications/notifiers/degrade'
+require 'rollout/notifications/notifiers/status_change'
+require 'rollout/version'
+
 
 class Rollout
 
@@ -33,14 +39,36 @@ class Rollout
     self
   end
 
+  def with_notifications(status_change:[], degrade:[])
+    status_change_channels = status_change
+    degrade_channels = degrade
+
+    if !status_change_channels.empty?
+      @status_change_notifier = Notifications::Notifiers::StatusChange.new(status_change_channels)
+    end
+
+    if !degrade_channels.empty?
+      @degrade_notifier = Notifications::Notifiers::Degrade.new(degrade_channels)
+    end
+
+    self
+  end
+
   def activate(feature_name, percentage=100)
     data = { percentage: percentage }
     feature = Feature.new(feature_name, data)
-    @cache[feature_name] = {
-      feature: feature,
-      timestamp: Time.now.to_i
-    } if @cache_enabled
-    save(feature) == "OK"
+    result = save(feature) == "OK"
+
+    if result
+      @cache[feature_name] = {
+        feature: feature,
+        timestamp: Time.now.to_i
+      } if @cache_enabled
+
+      @status_change_notifier&.notify(feature_name, :activated, percentage)
+    end
+
+    result
   end
 
   def activate_percentage(feature_name, percentage)
@@ -48,7 +76,11 @@ class Rollout
   end
 
   def deactivate(feature_name)
-    del(feature_name)
+    result = del(feature_name)
+
+    @status_change_notifier&.notify(feature_name, :deactivated)
+
+    result
   end
 
   def active?(feature_name, determinator = nil)
@@ -115,7 +147,11 @@ class Rollout
 
         @storage.set(new_key, new_data)
 
-        puts "Migrated key: #{old_key} to #{new_key} with data #{new_data}"
+        puts "Migrated key: #{old_key.gsub('feature:', '')} to #{new_key.gsub('feature-rollout-redis:', '')} with data #{new_data}"
+
+        if percentage > 0
+          @status_change_notifier&.notify(new_key.gsub('feature-rollout-redis:', ''), :activated, percentage)
+        end
       end
     end
   end
@@ -154,7 +190,13 @@ class Rollout
       degraded: true,
       degraded_at: Time.now
     })
-    @storage.set(key(feature.name), data_with_degrade.to_json)
+    result = @storage.set(key(feature.name), data_with_degrade.to_json) == "OK"
+
+    if result
+      @degrade_notifier.notify(feature_name, feature.requests, feature.errors)
+    end
+
+    result
   end
 
   def from_cache(feature_name)

--- a/lib/rollout/notifications/channels/email.rb
+++ b/lib/rollout/notifications/channels/email.rb
@@ -1,0 +1,31 @@
+require 'mail'
+
+class Rollout
+  module Notifications
+    module Channels
+      class Email
+        def initialize(smtp_host:, smtp_port:, from:'no-reply@rollout-redis.com', to:)
+          @smtp_host = smtp_host
+          @smtp_port = smtp_port
+          @from = from
+          @to = to
+        end
+
+        def publish(subject, body)
+          mail = Mail.new do
+            subject  subject
+            body     body
+          end
+          mail.smtp_envelope_from = @from
+          mail.smtp_envelope_to = @to
+          mail.delivery_method :smtp, address: @smtp_host, port: @smtp_port
+          mail.deliver
+        end
+
+        def type
+          :email
+        end
+      end
+    end
+  end
+end 

--- a/lib/rollout/notifications/channels/slack.rb
+++ b/lib/rollout/notifications/channels/slack.rb
@@ -1,0 +1,45 @@
+require 'slack-notifier'
+
+class Rollout
+  module Notifications
+    module Channels
+      class Slack
+        def initialize(webhook_url:, channel:, username:'rollout-redis')
+          @webhook_url = webhook_url
+          @channel = channel
+          @username = username
+        end
+
+        def publish(text)
+          begin
+            blocks = [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": text
+                }
+              }
+            ]
+            slack_notifier.post(blocks: blocks)
+          rescue => e
+            puts "[ERROR] Error sending notification to slack webhook. Error => #{e}"
+          end
+        end
+
+        def type
+          :slack
+        end
+
+        private
+
+        def slack_notifier
+          @notifier ||= ::Slack::Notifier.new @webhook_url do
+            defaults channel: @channel,
+                     username: @username
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rollout/notifications/notifiers/base.rb
+++ b/lib/rollout/notifications/notifiers/base.rb
@@ -1,0 +1,15 @@
+class Rollout
+  module Notifications
+    module Notifiers
+      class Base
+        def initialize(channels)
+          if channels.respond_to?(:first)
+            @channels = channels
+          else
+            @channels = [channels]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rollout/notifications/notifiers/degrade.rb
+++ b/lib/rollout/notifications/notifiers/degrade.rb
@@ -1,0 +1,33 @@
+require_relative 'base'
+
+class Rollout
+  module Notifications
+    module Notifiers
+      class Degrade < Base
+        def initialize(channels)
+          super(channels)
+        end
+
+        def notify(feature_name, requests, errors)
+          @channels.each do |c|
+            publish_for_slack_channel(c, feature_name, requests, errors) if c.type == :slack
+            publish_for_email_channel(c, feature_name, requests, errors) if c.type == :email
+          end
+        end
+
+        private
+
+        def publish_for_slack_channel(c, feature_name, requests, errors)
+          text = "Feature flag '#{feature_name}' has been degraded after #{requests} requests and #{errors} errors"
+          c.publish(text)
+        end
+
+        def publish_for_email_channel(c, feature_name, requests, errors)
+          subject = 'Feature flag has been automatically deactivated!'
+          content = "Feature flag '#{feature_name}' has been degraded after #{requests} requests and #{errors} errors"
+          c.publish(subject, content)
+        end
+      end
+    end
+  end
+end

--- a/lib/rollout/notifications/notifiers/status_change.rb
+++ b/lib/rollout/notifications/notifiers/status_change.rb
@@ -1,0 +1,42 @@
+require_relative 'base'
+
+class Rollout
+  module Notifications
+    module Notifiers
+      class StatusChange < Base
+        def initialize(channels)
+          super(channels)
+        end
+
+        def notify(feature_name, new_status, new_percentage=nil)
+          @channels.each do |c|
+            publish_for_slack_channel(c, feature_name, new_status, new_percentage) if c.type == :slack
+            publish_for_email_channel(c, feature_name, new_status, new_percentage) if c.type == :email
+          end
+        end
+
+        private
+
+        def publish_for_slack_channel(c, feature_name, new_status, new_percentage)
+          if new_status == :activated
+            text = "Feature flag '#{feature_name}' has been activated with percentage #{new_percentage}!"
+          elsif new_status == :deactivated
+            text = "Feature flag '#{feature_name}' has been deactivated and deleted!"
+          end
+          c.publish(text)
+        end
+
+        def publish_for_email_channel(c, feature_name, new_status, new_percentage)
+          if new_status == :activated
+            subject = 'Feature flag has been activated!'
+            content = "Feature flag '#{feature_name}' has been activated with percentage #{new_percentage}!"
+          elsif new_status == :deactivated
+            subject = 'Feature flag has been deactivated!'
+            content = "Feature flag '#{feature_name}' has been deactivated and deleted!"
+          end
+          c.publish(subject, content)
+        end
+      end
+    end
+  end
+end

--- a/lib/rollout/version.rb
+++ b/lib/rollout/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Rollout
-  VERSION = '0.3.1'
+  VERSION = '1.0.0'
 end

--- a/rollout-redis.gemspec
+++ b/rollout-redis.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_runtime_dependency 'redis', '>= 4.0', '<= 5'
+  spec.add_runtime_dependency 'slack-notifier', '~> 2.4'
+  spec.add_runtime_dependency 'mail', '~> 2.8'
 
   spec.add_development_dependency 'bundler', '>= 2.4'
   spec.add_development_dependency 'rspec', '~> 3.12'

--- a/sample/Gemfile
+++ b/sample/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'rollout-redis', path: '../'
+gem 'mock_redis', '~> 0.37'
+gem 'roda', '~> 3'

--- a/sample/Gemfile.lock
+++ b/sample/Gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: .
+  remote: ..
   specs:
     rollout-redis (1.0.0)
       mail (~> 2.8)
@@ -11,14 +11,13 @@ GEM
   specs:
     connection_pool (2.4.1)
     date (3.3.3)
-    diff-lcs (1.5.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
       net-pop
       net-smtp
     mini_mime (1.1.5)
-    mock_redis (0.37.0)
+    mock_redis (0.38.0)
     net-imap (0.4.2)
       date
       net-protocol
@@ -28,37 +27,23 @@ GEM
       timeout
     net-smtp (0.4.0)
       net-protocol
-    rake (13.0.6)
+    rack (3.0.8)
     redis (5.0.0)
       redis-client (~> 0.7)
     redis-client (0.17.1)
       connection_pool
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.2)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.3)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.6)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-support (3.12.1)
+    roda (3.73.0)
+      rack
     slack-notifier (2.4.0)
     timeout (0.4.0)
 
 PLATFORMS
-  aarch64-linux
   arm64-darwin-23
 
 DEPENDENCIES
-  bundler (>= 2.4)
   mock_redis (~> 0.37)
-  rake (~> 13)
+  roda (~> 3)
   rollout-redis!
-  rspec (~> 3.12)
 
 BUNDLED WITH
    2.4.21

--- a/sample/README.md
+++ b/sample/README.md
@@ -1,0 +1,25 @@
+# Sample Application 🏜️
+
+This is a sample RODA application that test the current implementation of the `rollout-redis` gem.
+
+If you want to run it, you just need to perform:
+
+```shell
+bundle install && rackup
+```
+
+It will start a server in [http://localhost:9292](http://localhost:9292)
+
+```shell
+Puma starting in single mode...
+* Puma version: 5.6.7 (ruby 3.2.2-p53) ("Birdie's Version")
+*  Min threads: 0
+*  Max threads: 5
+*  Environment: development
+*          PID: 43818
+* Listening on http://127.0.0.1:9292
+* Listening on http://[::1]:9292
+Use Ctrl-C to stop
+```
+
+If you want to test the notifications, please edit the `config.ru` file and update the `SLACK_WEBHOOK_URL` and `SMTP_HOST` variables when defining the available channels.

--- a/sample/config.ru
+++ b/sample/config.ru
@@ -1,0 +1,105 @@
+require "rollout"
+require "roda"
+require "mock_redis"
+
+class App < Roda
+  route do |r|
+    @storage ||= MockRedis.new
+
+    # GET / request
+    r.root do
+      r.redirect "/main"
+    end
+
+    # /main branch
+    r.on "main" do
+      r.is do
+        r.get do
+
+          # Defining channels where the notifications will be sent
+          # Slack channel
+          SLACK_WEBHOOK_URL = 'YOUR_WEBHOOK_URL'.freeze
+          slack_channel = Rollout::Notifications::Channels::Slack.new(
+            webhook_url: SLACK_WEBHOOK_URL,
+            channel: '#rollout-redis-test-jc'
+          )
+          # Email channel
+          SMTP_HOST = 'YOUR_SMTP_SERVER'.freeze
+          email_channel = Rollout::Notifications::Channels::Email.new(
+            smtp_host: SMTP_HOST,
+            smtp_port: '25',
+            from: 'rollout@my-app.com',
+            to: 'developers@myteam.com'
+          )
+
+          rollout = Rollout.new(@storage)
+                      .with_cache
+                      .with_degrade(min: 1, threshold: 0.1)
+                      .with_notifications(status_change: [slack_channel], degrade: [slack_channel, email_channel])
+
+          activated_feature_flags = []
+
+          msg = "<h1>rollout-redis</h1>"
+          msg << "<h2>Testing features</h2>"
+
+          msg << "<p>1. Activating multiple feature flags with different percentages</p>"
+          msg << "<ul>"
+          feature_flag_name = "my-first-feature-flag"
+          activated_feature_flags << feature_flag_name
+          msg << "<li>Activating feature flag #{feature_flag_name} with 100% => #{rollout.activate(feature_flag_name)}</li>"
+          5.times do |i|
+            characters = [('a'..'z'), ('A'..'Z')].map(&:to_a).flatten
+            feature_flag_name = (0...15).map { characters[rand(characters.length)] }.join
+            percentage = rand(0...100)
+
+            activated_feature_flags << feature_flag_name
+
+            msg << "<li>Activating feature flag #{feature_flag_name} with #{percentage}% => #{rollout.activate(feature_flag_name, percentage)}</li>"
+          end
+          feature_flag_name = "my-last-feature-flag"
+          msg << "<li>Activating feature flag #{feature_flag_name} with 0% => #{rollout.activate(feature_flag_name, 0)}</li>"
+          activated_feature_flags << feature_flag_name
+          msg << "</ul>"
+
+          if rollout.active?('my-first-feature-flag')
+            msg << "<p>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</p>"
+            msg << "<p>xxxxxxxxxxxxxx This code is only visible if my-first-feature-flag FF is active xxxxxxxxxxxxxx</p>"
+            msg << "<p>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</p>"
+          end
+
+          msg << "<p>2. Listing all the activated feature flags and checking if active for different users:</p>"
+          msg << "<ul>"
+          user_emails = ['user-email@gmail.com', 'another-user-email@gmail.com', 'super-user-email@gmail.com']
+          rollout.features.each do |feature|
+            msg << "<li>#{feature[:name]} (#{feature[:percentage]}%). <ul>"
+            user_emails.each do |user_email|
+              msg << "<li>Active for '#{user_email}'? => #{rollout.active?(feature[:name], user_email)}</li>"
+            end
+            msg << "</ul></li>"
+          end
+          msg << "</ul>"
+
+          msg << "<p>3. Checking auto deactivation when error in the released code</p>"
+          msg << "<ul>"
+          msg << "<li>my-first-feature-flag (100%)<ul>"
+          10.times do
+            begin
+              rollout.with_feature_flag('my-first-feature-flag') do
+                raise "My code has an error"
+              end
+            rescue
+            end
+          end
+
+          msg << "<li> The feature flag was active, but somehing was wrong performing the released code</li>"
+          msg << "<li> Has been auto-deactivated? => #{!rollout.active?('my-first-feature-flag')}</li>"
+          msg << "</ul></li></ul>"
+
+          msg
+        end
+      end
+    end
+  end
+end
+
+run App.freeze.app

--- a/spec/notifications_spec.rb
+++ b/spec/notifications_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+RSpec.describe Rollout do
+
+  let(:storage) { MockRedis.new }
+  let(:instance) { described_class.new(storage)}
+  let(:feature_flag_name) { 'A_FEATURE_FLAG_NAME'}
+
+  let(:slack_channel) do
+    Rollout::Notifications::Channels::Slack.new(webhook_url: 'a-url', channel: '#my-channel')
+  end
+  let(:email_channel) do
+    Rollout::Notifications::Channels::Email.new(smtp_host: 'localhost', smtp_port: '587', to: 'developers@mycompany.com')
+  end
+
+  describe '#with_notifications' do
+    let(:channels) do
+      [
+        slack_channel,
+        email_channel
+      ]
+    end
+
+    context 'when status_change event has channels defined' do
+      let(:instance_with_notifications) do
+        instance.with_notifications(status_change: channels)
+      end
+
+      context 'when new feature flag is activated' do
+        it 'sends the notification to the defined channels' do
+          feature_flag_name = 'a-feature-flag'
+          percentage = 87
+
+          expected_subject = "Feature flag has been activated!"
+          expected_message = "Feature flag '#{feature_flag_name}' has been activated with percentage #{percentage}!"
+
+          expect(slack_channel).to receive(:publish).with(expected_message)
+          expect(email_channel).to receive(:publish).with(expected_subject, expected_message)
+
+          instance_with_notifications.activate(feature_flag_name, percentage)
+        end
+      end
+
+      context 'when a feature flag is deactivated' do
+        it 'sends the notification to the defined channels' do
+          feature_flag_name = 'a-feature-flag'
+
+          expected_subject = "Feature flag has been deactivated!"
+          expected_message = "Feature flag '#{feature_flag_name}' has been deactivated and deleted!"
+
+          expect(slack_channel).to receive(:publish).with(expected_message)
+          expect(email_channel).to receive(:publish).with(expected_subject, expected_message)
+
+          instance_with_notifications.deactivate(feature_flag_name)
+        end
+      end
+
+      context 'when migrating from the old rollout gem format' do
+        context 'when the existing feature flag is active' do
+          before do
+            storage.set("feature:old-key", "100|||{}")
+          end
+
+          it 'sends the proper notifications to the defined channels' do
+            expected_subject = "Feature flag has been activated!"
+            expected_message = "Feature flag 'old-key' has been activated with percentage 100!"
+  
+            expect(slack_channel).to receive(:publish).with(expected_message)
+            expect(email_channel).to receive(:publish).with(expected_subject, expected_message)
+
+            instance_with_notifications.migrate_from_rollout_format
+          end
+        end
+      end
+    end
+
+    context 'when degrade event has channels defined' do
+      context 'when the instance is configured for degrading feature flags' do
+        let(:instance_with_degrade_and_notifications) do
+          instance
+            .with_degrade(min: 100, threshold: 0.5)
+            .with_notifications(degrade: channels)
+        end
+  
+        context 'and a feature flag reaches the threshold of errors' do
+          it 'sends the degraded notification to the defined channels' do
+            feature_flag_name = 'a-feature-flag'
+            instance_with_degrade_and_notifications.activate(feature_flag_name)
+
+            expected_subject = "Feature flag has been automatically deactivated!"
+            expected_message = "Feature flag '#{feature_flag_name}' has been degraded after 101 requests and 51 errors"
+  
+            expect(slack_channel).to receive(:publish).with(expected_message)
+            expect(email_channel).to receive(:publish).with(expected_subject, expected_message)
+
+            101.times do |i|
+              begin
+                instance_with_degrade_and_notifications.with_feature_flag(feature_flag_name) do
+                  raise "error" if i.even?
+                end
+              rescue
+              end
+            end
+          end
+        end 
+      end
+    end
+  end
+end


### PR DESCRIPTION
We have added a new instance method `#with_notifications` that allows the users of the gem to specify the channels where a notification will be sent for some different types of events.